### PR TITLE
Stream vinyl file objects: images in and icons out 

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,50 @@
             });
         }
 
+        if (params.hasOwnProperty('settings') &&
+                params.settings.hasOwnProperty('vinylMode') &&
+                params.settings.vinylMode) {
+
+            var options = favicons.getConfig(params);
+
+            return through2.obj(function (file, enc, cb) {
+
+                if (file.isNull()) {
+                    cb(null, file);
+                    return;
+                }
+
+                if (file.isStream()) {
+                    cb(new util.PluginError('gulp-favicons',
+                            'Streaming not supported'));
+                    return;
+                }
+
+                options.data.favicon_generation.master_picture = { type: 'inline', content: file.contents.toString('base64') };
+
+                return cb();
+
+            }, function (cb) {
+
+                var that = this;
+
+                favicons.generateFaviconStream(options, function (error, data) {
+                    console.log(data);
+                })
+                    .on('entry', function (entry) {
+                        that.push(new util.File({
+                            path: entry.path,
+                            contents: entry
+                        }));
+                    })
+                    .on('end', function () {
+                        cb();
+                    });
+
+            });
+
+        }
+
         return through2.obj(function (file, enc, cb) {
 
             findInfo(file.path, function (error, info) {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
         path = require('path'),
         favicons = require('favicons');
 
-    module.exports = function (params) {
+    module.exports = function (params, htmlCodeCallback) {
 
         function findInfo(source, callback) {
             fs.readFile(source, function (error, data) {
@@ -56,16 +56,19 @@
                 var that = this;
 
                 favicons.generateFaviconStream(options, function (error, data) {
-                    console.log(data);
+                    if (error) {
+                        that.end();
+                        cb(error);
+                    }
+                    if (htmlCodeCallback) {
+                        htmlCodeCallback(data.favicon_generation_result.favicon.html_code);
+                    }
                 })
                     .on('entry', function (entry) {
                         that.push(new util.File({
                             path: entry.path,
                             contents: entry
                         }));
-                    })
-                    .on('end', function () {
-                        cb();
                     });
 
             });

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -1,10 +1,18 @@
 var gulp = require('gulp'),
+    through = require('through2'),
     favicons = require('../');
 
 gulp.task('default', function () {
     gulp.src('logo.png')
         .pipe(favicons({
-          settings: { background: '#1d1d1d' , vinylMode: true }
+            settings: { background: '#1d1d1d' , vinylMode: true }
+        }, function(code) {
+            console.log(code);
+        }))
+        .pipe(through.obj(function (file, enc, cb) {
+            console.log(file.path);
+            this.push(file);
+            cb();
         }))
         .pipe(gulp.dest('./images'));
 });

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -2,10 +2,9 @@ var gulp = require('gulp'),
     favicons = require('../');
 
 gulp.task('default', function () {
-    gulp.src('index.html')
+    gulp.src('logo.png')
         .pipe(favicons({
-            files: { dest: 'images/' },
-            settings: { background: '#1d1d1d' }
+          settings: { background: '#1d1d1d' , vinylMode: true }
         }))
-        .pipe(gulp.dest('./'));
+        .pipe(gulp.dest('./images'));
 });


### PR DESCRIPTION
This aims to solve #2. Unless the params passed in include a truthy `vinylMode` property, the behavior is the same as before. When such a property is passed in, the plugin takes images from the incoming stream, uses `favicons` to generate icons from those images, and yields those icons on the outgoing stream. In this mode, a second argument, `htmlCodeCallback`, will be called with a string of html code corresponding to the generated icons.

This requires haydenbleasel/favicons#35, which maybe should be indicated via `npm` versioning.